### PR TITLE
Add missing go.mod

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,8 @@
+module github.com/blgm/foo/v2
+
+go 1.15
+
+require (
+	github.com/onsi/ginkgo v1.16.1
+	github.com/onsi/gomega v1.11.0
+)


### PR DESCRIPTION
v2 packages are supposed to have their own go.mod making them standalone modules